### PR TITLE
add additional types to CiviLegislationData

### DIFF
--- a/api/types.ts
+++ b/api/types.ts
@@ -5,11 +5,15 @@ export interface CiviLegislationData {
   id: string;
   title: string;
   link: string;
+  url?: string;
   source_id: string;
   sponsors: { name: string; role: string; district: string }[];
   classification?: string;
   description?: string;
   tags?: string[];
+  updated_at?: string;
+  voteHistory?: { motion_classification: string[]; created_at: string }[];
+  identifier?: string;
   summaries?: {
     gpt: string;
   };

--- a/scraper/api/bunkum.ts
+++ b/scraper/api/bunkum.ts
@@ -164,7 +164,7 @@ async function getChicagoBills() {
       // We ignore the error
     }
 
-    return {
+    const bills: CiviLegislationData = {
       id: bill.id,
       title: bill.title,
       tags: JSON.parse(bill.extras).topics,
@@ -186,7 +186,9 @@ async function getChicagoBills() {
       identifier: bill.identifier,
       link: `https://chicago.councilmatic.org/legislation/${bill.identifier}`,
       url: `https://chicago.councilmatic.org/legislation/${bill.identifier}`,
-    } as CiviLegislationData;
+    };
+
+    return bills;
   });
 
   return results;


### PR DESCRIPTION
-add types to CiviLegistlationData

can we use the following output (take a look at status, statusDate, and motion_classification):

{
    "id": "ocd-bill/309672ae-25f9-42c4-8d59-39132c22ab85",
    "title": "Amendment of Municipal Code Section 4-60-023 (49.41) to disallow additional package goods licenses on portion(s) of W Lunt Ave",
    "tags": [
      "Ward Matters",
      "Land Use",
      "Liquor and Package Store Restrictions"
    ],
    "status": "[\"passage\"]",
    "updated_at": "2024-02-21",
    "statusDate": "2024-02-21 - [\"passage\"]",
    "sponsors": [
      {
        "name": "Hadden, Maria E.",
        "person_id": "ocd-person/ee81d895-761c-49d2-8ea2-e2f7ec1f2a8b",
        "role": "",
        "district": ""
      }
    ],
    "voteHistory": [
      {
        "motion_classification": "[\"passage\"]",
        "created_at": "2024-02-23T04:23:30.732280+00:00"
      }
    ],
    "source_id": "",
    "classification": "ordinance",
    "identifier": "O2023-0006144",
    "link": "https://chicago.councilmatic.org/legislation/O2023-0006144",
    "url": "https://chicago.councilmatic.org/legislation/O2023-0006144"
  },